### PR TITLE
Implement basic expression parser for arithmetic operators

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,31 +1,21 @@
 // src/main.rs
 mod c4;
 
-use c4::{Lexer, Token};
+use c4::{Parser, Expr};
 use std::env;
 use std::fs;
 
 fn main() -> Result<(), String> {
-    // Get command-line arguments
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         return Err(format!("Usage: {} <source.c>", args[0]));
     }
 
-    // Read input file
     let input = fs::read_to_string(&args[1]).map_err(|e| format!("Failed to read {}: {}", args[1], e))?;
 
-    // Initialize lexer
-    let mut lexer = Lexer::new(&input);
-
-    // Process tokens until EOF or error
-    loop {
-        match lexer.next() {
-            Ok(Token::Eof) => break,
-            Ok(token) => println!("{:?}", token),
-            Err(e) => return Err(e),
-        }
-    }
+    let mut parser = Parser::new(&input);
+    let expr = parser.parse_expr()?;
+    println!("{:#?}", expr);
 
     Ok(())
 }


### PR DESCRIPTION
Added to `src/c4.rs`:
- `Expr` enum for AST (numbers, binary operations).
- `Parser` struct with `parse_expr`, `parse_term`, `parse_factor` for `+`, `-`, `*`, `/`.
- Unit tests for parsing numbers, additions, precedence, parentheses, and errors.
Updated `src/main.rs` to parse and print the AST for an expression.
All tests pass with `cargo test`.
Tested with expressions like `1 + 2 * 3` and `(1 + 2) * 3`.